### PR TITLE
Add default date for the submission date

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -26,6 +26,9 @@
 \author{Your Name}
 \matrikelnr{1234567}
 
+% Can be set with `\submitDate[someDate]`. Otherwise it will use the date of compilation and the formatting defined by the language, set via language settings below.
+\submitDate
+
 % -----------------------------------------------------------------------------------
 % English chair and thesis info
 % -----------------------------------------------------------------------------------
@@ -34,7 +37,6 @@
 
 \thesisType{Master's Thesis}
 \thesisTitle{Creation of a \LaTeX~Template for\\Students to use for their Thesis}
-\submitDate
 \editingTime{July 13, 2021 - March 10, 2022}
 
 % Examiners
@@ -60,7 +62,6 @@
 % \thesisType{Master Thesis}
 % \thesisTitle{Erstellung einer \LaTeX~Vorlage für\\
 %             Abschlussabeiten von Studierenden}
-% \submitDate
 % \editingTime{13. Juli 2021 - 10. März 2022}
 
 % % Examiners

--- a/main.tex
+++ b/main.tex
@@ -34,7 +34,7 @@
 
 \thesisType{Master's Thesis}
 \thesisTitle{Creation of a \LaTeX~Template for\\Students to use for their Thesis}
-\submitDate{March 10, 2022}
+\submitDate{\today}
 \editingTime{July 13, 2021 - March 10, 2022}
 
 % Examiners
@@ -60,7 +60,7 @@
 % \thesisType{Master Thesis}
 % \thesisTitle{Erstellung einer \LaTeX~Vorlage für\\
 %             Abschlussabeiten von Studierenden}
-% \submitDate{10. März 2022}
+% \submitDate{\today}
 % \editingTime{13. Juli 2021 - 10. März 2022}
 
 % % Examiners

--- a/main.tex
+++ b/main.tex
@@ -34,7 +34,7 @@
 
 \thesisType{Master's Thesis}
 \thesisTitle{Creation of a \LaTeX~Template for\\Students to use for their Thesis}
-\submitDate{\today}
+\submitDate
 \editingTime{July 13, 2021 - March 10, 2022}
 
 % Examiners
@@ -60,7 +60,7 @@
 % \thesisType{Master Thesis}
 % \thesisTitle{Erstellung einer \LaTeX~Vorlage für\\
 %             Abschlussabeiten von Studierenden}
-% \submitDate{\today}
+% \submitDate
 % \editingTime{13. Juli 2021 - 10. März 2022}
 
 % % Examiners

--- a/settings+/variables.tex
+++ b/settings+/variables.tex
@@ -38,7 +38,7 @@
 % Thesis
 \newcommand*{\thesisType}[1]{\gdef\@thesisType{#1}}
 \newcommand*{\thesisTitle}[1]{\gdef\@thesisTitle{#1}}
-\newcommand*{\submitDate}[1]{\gdef\@submitDate{#1}}
+\newcommand*{\submitDate}[1][\today]{\gdef\@submitDate{#1}}
 \newcommand*{\editingTime}[1]{\gdef\@editingTime{#1}}
 
 % Examiners


### PR DESCRIPTION
I reworked the `submitDate` command to have a default value (Day of the compilation), which is formatted based on the language set via language settings.
Users can still pass a date manually, if they do not want the compilation date.

However, based on my previous experience with seminars, there is a high chance, that the latex project will have be changed on the date of the submission and will have to be compiled one last time. So why not save the poor author from having to remember to manually set the date?