### PR TITLE
Added configuration for VS Code "LaTeX Workshop" plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "latex-workshop.latex.autoBuild.run": "onSave",
+    "latex-workshop.latex.recipes": [
+        {
+            "name": "latexmk",
+            "tools": [
+                "latexmk"
+            ]
+        }
+    ],
+    "latex-workshop.latex.tools": [
+        {
+            "name": "latexmk",
+            "command": "latexmk",
+        }
+    ]
+}


### PR DESCRIPTION
Due to the projects compile time being to long to run on a free-tier Overleaf Account, I added VS Code workspace configuration files to build the project locally using "LaTeX Workshop" plugin in Visual Studio Code.

Currently I only tested it on Ubuntu 22.04.4 with texlive-full installed, but in theory it should work on all systems where latexmk is installed and accessible over the command line (not sure how Windows handles that).